### PR TITLE
Revert "tasks/main.yml: Validate systemd unit files"

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -79,7 +79,6 @@
     group: root
     owner: root
     mode: 0644
-    validate: systemd-analyze verify %s
   register: sigservice
 
 - name: Install systemd timer file (clamav-unofficial-sigs.timer)
@@ -89,7 +88,6 @@
     group: root
     owner: root
     mode: 0644
-    validate: systemd-analyze verify %s
   register: sigtimer
 
 - name: Enable systemd timer


### PR DESCRIPTION
Reverts stuvusIT/clamav-unofficial-sigs#3
Validating does not work, because Ansible does not use the correct file suffix in its temp files. That suffix would be needed for systemd to detect the unti type. See https://github.com/ansible/ansible/issues/19232